### PR TITLE
Enable security keys

### DIFF
--- a/configure-for-osx.sh
+++ b/configure-for-osx.sh
@@ -4,7 +4,6 @@ set -v
 
 cd openssh
 ./configure --with-pam --with-audit=bsm --with-kerberos5=/usr \
- --disable-security-key \
  --disable-libutil \
  --disable-pututline \
  --with-xauth="xauth" \


### PR DESCRIPTION
Right now security keys support is disabled in MacOS openssh distribution. But for some use-cases, they are very useful

https://developer.apple.com/forums/thread/698683